### PR TITLE
Allow setting of Format in get_log_job

### DIFF
--- a/pybuildkite/buildkite.py
+++ b/pybuildkite/buildkite.py
@@ -2,7 +2,7 @@ from pybuildkite.client import Client
 from pybuildkite.organizations import Organizations
 from pybuildkite.pipelines import Pipelines
 from pybuildkite.builds import Builds, BuildState
-from pybuildkite.jobs import Jobs
+from pybuildkite.jobs import Jobs, LogFormat
 from pybuildkite.agents import Agents
 from pybuildkite.emojis import Emojis
 from pybuildkite.annotations import Annotations

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -1,4 +1,18 @@
+from enum import Enum
+
 from pybuildkite.client import Client
+
+
+class LogFormat(Enum):
+    """
+    Valid log formats
+    """
+
+    TEXT = "text/plain"
+    HTML = "text/html"
+
+    def __str__(self):
+        return self.value
 
 
 class Jobs(Client):
@@ -17,7 +31,7 @@ class Jobs(Client):
         self.path = base_url + "/organizations/{}/pipelines/{}/builds/{}/jobs/{}/"
 
     def get_job_log(
-        self, organization, pipeline, build, job, get_text=False, get_html=False
+        self, organization, pipeline, build, job, log_format=LogFormat.HTML
     ):
         """
         Get a job’s log output
@@ -26,11 +40,10 @@ class Jobs(Client):
         :param pipeline: Pipeline slug
         :param build: Build number
         :param job: Job id
-        :param get_text: Unused
-        :param get_html: Unused
+        :param log_format: Mime type to return log in
         :return: Job log output
         """
-        header = {"Accept": "text/html"}
+        header = {"Accept": str(log_format)}
         return self.client.get(
             self.path.format(organization, pipeline, build, job) + "log", headers=header
         )

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,57 @@
+from unittest.mock import Mock
+
+import pytest
+
+from pybuildkite.jobs import Jobs, LogFormat
+
+
+class TestJobs:
+    """
+    Test functionality of the Jobs class
+    """
+
+    @pytest.fixture
+    def fake_client(self):
+        """
+        Build a fake API client
+        """
+        return Mock(get=Mock())
+
+    def test_job_logs_can_be_requested_in_a_default_format(self, fake_client):
+        """
+        Test job logs can be requested in a default format
+        """
+        jobs = Jobs(fake_client, "base")
+        jobs.get_job_log("org_slug", "pipe_slug", "build_no", 123)
+        url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/log"
+        fake_client.get.assert_called_with(url, headers={"Accept": "text/html"})
+
+    def test_job_logs_can_be_requested_in_a_user_specified_format(self, fake_client):
+        """
+        Test job logs can be requested in a user specified format
+        """
+        jobs = Jobs(fake_client, "base")
+        jobs.get_job_log("org_slug", "pipe_slug", "build_no", 123, "some/thing")
+        url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/log"
+        fake_client.get.assert_called_with(url, headers={"Accept": "some/thing"})
+
+    def test_job_logs_can_be_requested_in_a_predefined_format(self, fake_client):
+        """
+        Test job logs can be requested in a predefined format
+        """
+        jobs = Jobs(fake_client, "base")
+        jobs.get_job_log("org_slug", "pipe_slug", "build_no", 123, LogFormat.TEXT)
+        url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/log"
+        fake_client.get.assert_called_with(url, headers={"Accept": "text/plain"})
+
+
+class TestLogFormat:
+    """
+    Test functionality of the LogFormat class
+    """
+
+    def test_log_format_can_be_nicely_printed_like_a_string(self):
+        """
+        Test that the log can be nicely formatted like a string
+        """
+        assert str(LogFormat.HTML) == "text/html"


### PR DESCRIPTION
This removes some unused parameters from the API.

As mentioned in PR #8