### PR TITLE
Fix key and path issues in jobs and fix client response content type

### DIFF
--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -59,6 +59,7 @@ class Client(object):
             body = self._clean_query_params(body)
 
         query_params["per_page"] = "100"
+
         query_params = self._convert_query_params_to_string_for_bytes(query_params)
         response = requests.request(
             method, url, headers=headers, params=str.encode(query_params), json=body
@@ -71,8 +72,10 @@ class Client(object):
             return response
         if method == "DELETE":
             return response.ok
-        else:
+        if headers == None or headers.get('Accept') == 'application/json':
             return response.json()
+        else:
+            return response.text
 
     def _get_paginated_response(self, response):
         """

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -72,7 +72,7 @@ class Client(object):
             return response
         if method == "DELETE":
             return response.ok
-        if headers == None or headers.get('Accept') == 'application/json':
+        if headers == None or headers.get("Accept") == "application/json":
             return response.json()
         else:
             return response.text

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -89,7 +89,7 @@ class Jobs(Client):
            :return: response
         """
         unblock = "/unblock"
-        body = {"field": fields, "unblocker": unblocker}
+        body = {"fields": fields, "unblocker": unblocker}
         return self.client.put(
             self.path.format(organization, pipeline, build, job) + unblock, body=body
         )

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -10,6 +10,7 @@ class LogFormat(Enum):
 
     TEXT = "text/plain"
     HTML = "text/html"
+    JSON = "application/json"
 
     def __str__(self):
         return self.value

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -29,7 +29,7 @@ class Jobs(Client):
         :param base_url: Base Url
         """
         self.client = client
-        self.path = base_url + "organizations/{}/pipelines/{}/builds/{}/jobs/{}/"
+        self.path = base_url + "organizations/{}/pipelines/{}/builds/{}/jobs/{}"
 
     def get_job_log(
         self, organization, pipeline, build, job, log_format=LogFormat.HTML
@@ -46,7 +46,7 @@ class Jobs(Client):
         """
         header = {"Accept": str(log_format)}
         return self.client.get(
-            self.path.format(organization, pipeline, build, job) + "log", headers=header
+            self.path.format(organization, pipeline, build, job) + "/log", headers=header
         )
 
     def get_job_environment_variables(self, organization, pipeline, build, job):
@@ -60,7 +60,7 @@ class Jobs(Client):
         :return: Environment variables
         """
         return self.client.get(
-            self.path.format(organization, pipeline, build, job) + "env"
+            self.path.format(organization, pipeline, build, job) + "/env"
         )
 
     def retry_job(self, organization, pipeline, build, job):

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -28,7 +28,7 @@ class Jobs(Client):
         :param base_url: Base Url
         """
         self.client = client
-        self.path = base_url + "/organizations/{}/pipelines/{}/builds/{}/jobs/{}/"
+        self.path = base_url + "organizations/{}/pipelines/{}/builds/{}/jobs/{}/"
 
     def get_job_log(
         self, organization, pipeline, build, job, log_format=LogFormat.HTML

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -46,7 +46,8 @@ class Jobs(Client):
         """
         header = {"Accept": str(log_format)}
         return self.client.get(
-            self.path.format(organization, pipeline, build, job) + "/log", headers=header
+            self.path.format(organization, pipeline, build, job) + "/log",
+            headers=header,
         )
 
     def get_job_environment_variables(self, organization, pipeline, build, job):

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -23,7 +23,5 @@ class TestAgents:
         """
         agents = Agents(fake_client, "base")
         artifacts.get_agent("org_slug", "agent_id")
-        url = (
-            "baseorganizations/org_slug/agents/agent_id"
-        )
+        url = "baseorganizations/org_slug/agents/agent_id"
         fake_client.get.assert_called_with(url)


### PR DESCRIPTION
Fixes several errors in Jobs class, in base_url, log, env, and fields for unblock. E.g.,
`500 Server Error: Internal Server Error for url: https://api.buildkite.com/v2//organizations/...`