### PR TITLE
Use Authorization header for authentication

### DIFF
--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -61,7 +61,7 @@ class Client(object):
                 # copy the dict so that the below logic for determining if json should
                 # be returned is correct
                 headers_with_auth = dict(headers)
-            headers_with_auth['Authorization'] = 'Bearer {}'.format(self.access_token)
+            headers_with_auth["Authorization"] = "Bearer {}".format(self.access_token)
 
         if body:
             body = self._clean_query_params(body)
@@ -70,7 +70,11 @@ class Client(object):
 
         query_params = self._convert_query_params_to_string_for_bytes(query_params)
         response = requests.request(
-            method, url, headers=headers_with_auth, params=str.encode(query_params), json=body
+            method,
+            url,
+            headers=headers_with_auth,
+            params=str.encode(query_params),
+            json=body,
         )
 
         response.raise_for_status()

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -50,16 +50,19 @@ class Client(object):
         :param with_pagination: Bool to return a response with pagination attributes
         :return: If headers are set response text is returned, otherwise parsed response is returned
         """
-        number_of_passed_in_headers = 0 if headers is None else len(headers)
+        if headers is None:
+            raise ValueError("headers cannot be None")
 
-        query_params = self._clean_query_params(query_params or {})
+        if not headers.get("Accept"):
+            headers["Accept"] = "application/json"
 
-        if self.access_token and headers is not None:
+        if self.access_token:
             headers["Authorization"] = "Bearer {}".format(self.access_token)
 
         if body:
             body = self._clean_query_params(body)
 
+        query_params = self._clean_query_params(query_params or {})
         query_params["per_page"] = "100"
 
         query_params = self._convert_query_params_to_string_for_bytes(query_params)
@@ -74,10 +77,7 @@ class Client(object):
             return response
         if method == "DELETE":
             return response.ok
-        if (
-            number_of_passed_in_headers == 0
-            or headers.get("Accept") == "application/json"
-        ):
+        if headers.get("Accept") == "application/json":
             return response.json()
         else:
             return response.text

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -53,9 +53,6 @@ class Client(object):
         if headers is None:
             raise ValueError("headers cannot be None")
 
-        if not headers.get("Accept"):
-            headers["Accept"] = "application/json"
-
         if self.access_token:
             headers["Authorization"] = "Bearer {}".format(self.access_token)
 
@@ -77,7 +74,7 @@ class Client(object):
             return response
         if method == "DELETE":
             return response.ok
-        if headers.get("Accept") == "application/json":
+        if headers.get("Accept") is None or headers.get("Accept") == "application/json":
             return response.json()
         else:
             return response.text

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -138,7 +138,7 @@ class TestClientRequest:
         client.set_client_access_token("ABCDEF1234")
 
         with patch("requests.request") as request:
-            request.return_value.json.return_value = {}
+            request.return_value.json.return_value = {"key": "value"}
 
             client.request("GET", "http://www.google.com/")
 
@@ -150,3 +150,26 @@ class TestClientRequest:
             json=None,
             params=expected_params,
         )
+
+    def test_request_should_return_json_when_no_header_provided(self):
+        """
+        Test that the requests response.json() decoding is returned when
+        no accept header is provided
+        """
+        client = Client()
+
+        with patch("requests.request") as request:
+            request.return_value.json.return_value = {"key": "value"}
+
+            ret = client.request("GET", "http://www.google.com/")
+
+        expected_params = b"per_page=100"
+        request.assert_called_once_with(
+            "GET",
+            "http://www.google.com/",
+            headers={},
+            json=None,
+            params=expected_params,
+        )
+
+        assert ret == {"key": "value"}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,10 +107,34 @@ class TestClientRequest:
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers={},
+            headers={"Accept": "application/json"},
             json=None,
             params=b"per_page=100",
         )
+
+    def test_request_preserves_accept_header(self):
+        """
+        Test that the accept header is not overwritten and that text is returned
+        """
+        client = Client()
+
+        with patch("requests.request") as request:
+            request.return_value.text = "response text"
+
+            resp_text = client.request("GET", "http://www.google.com/", headers={"Accept": "application/fake_encoding"})
+
+        expected_params = b"per_page=100"
+        request.assert_called_once_with(
+            "GET",
+            "http://www.google.com/",
+            headers={"Accept": "application/fake_encoding"},
+            json=None,
+            params=expected_params,
+        )
+
+        assert resp_text == "response text"
+
+
 
     def test_request_should_include_token_when_set(self):
         """
@@ -129,7 +153,8 @@ class TestClientRequest:
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers={"Authorization": "Bearer ABCDEF1234"},
+            headers={"Accept": "application/json",
+                "Authorization": "Bearer ABCDEF1234"},
             json=None,
             params=expected_params,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,18 +40,9 @@ class TestResponse:
     @pytest.mark.parametrize(
         "url,expected_output",
         [
-            (
-                "https://api.buildkite.com/v2/organization/builds?page=2&commit=SHA",
-                2,
-            ),
-            (
-                "https://api.buildkite.com/v2/page/builds?page=5&commit=SHA",
-                5,
-            ),
-            (
-                "https://api.buildkite.com/v2/page/builds?commit=SHA",
-                0,
-            ),
+            ("https://api.buildkite.com/v2/organization/builds?page=2&commit=SHA", 2),
+            ("https://api.buildkite.com/v2/page/builds?page=5&commit=SHA", 5),
+            ("https://api.buildkite.com/v2/page/builds?commit=SHA", 0),
         ],
     )
     def test_getting_page_from_url(self, url, expected_output):
@@ -121,7 +112,11 @@ class TestClientRequest:
         with patch("requests.request") as request:
             request.return_value.text = "response text"
 
-            resp_text = client.request("GET", "http://www.google.com/", headers={"Accept": "application/fake_encoding"})
+            resp_text = client.request(
+                "GET",
+                "http://www.google.com/",
+                headers={"Accept": "application/fake_encoding"},
+            )
 
         expected_params = b"per_page=100"
         request.assert_called_once_with(
@@ -133,8 +128,6 @@ class TestClientRequest:
         )
 
         assert resp_text == "response text"
-
-
 
     def test_request_should_include_token_when_set(self):
         """
@@ -153,8 +146,10 @@ class TestClientRequest:
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers={"Accept": "application/json",
-                "Authorization": "Bearer ABCDEF1234"},
+            headers={
+                "Accept": "application/json",
+                "Authorization": "Bearer ABCDEF1234",
+            },
             json=None,
             params=expected_params,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,15 +41,15 @@ class TestResponse:
         "url,expected_output",
         [
             (
-                "https://api.buildkite.com/v2/organization/builds?access_token=F@keT0k3N&page=2&commit=SHA",
+                "https://api.buildkite.com/v2/organization/builds?page=2&commit=SHA",
                 2,
             ),
             (
-                "https://api.buildkite.com/v2/page/builds?access_token=F@keT0k3N&page=5&commit=SHA",
+                "https://api.buildkite.com/v2/page/builds?page=5&commit=SHA",
                 5,
             ),
             (
-                "https://api.buildkite.com/v2/page/builds?access_token=F@keT0k3N&commit=SHA",
+                "https://api.buildkite.com/v2/page/builds?commit=SHA",
                 0,
             ),
         ],
@@ -125,11 +125,11 @@ class TestClientRequest:
 
             client.request("GET", "http://www.google.com/")
 
-        expected_params = b"access_token=ABCDEF1234&per_page=100"
+        expected_params = b"per_page=100"
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers=None,
+            headers={"Authorization": "Bearer ABCDEF1234"},
             json=None,
             params=expected_params,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -107,7 +107,7 @@ class TestClientRequest:
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers=None,
+            headers={},
             json=None,
             params=b"per_page=100",
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,7 +98,7 @@ class TestClientRequest:
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers={"Accept": "application/json"},
+            headers={},
             json=None,
             params=b"per_page=100",
         )
@@ -146,10 +146,7 @@ class TestClientRequest:
         request.assert_called_once_with(
             "GET",
             "http://www.google.com/",
-            headers={
-                "Accept": "application/json",
-                "Authorization": "Bearer ABCDEF1234",
-            },
+            headers={"Authorization": "Bearer ABCDEF1234"},
             json=None,
             params=expected_params,
         )


### PR DESCRIPTION
### Summary
Using the `access_token` query parameter runs the risk of exposing the
access token in exception stack traces. Switch to using an
`Authorization: Bearer token` header instead.

Some of the exceptions raised by requests include the url in the
exception text. If the stack trace is shared publicly somewhere, this
would lead to the exposure of an API token.

This change required a change to how page numbers are out of a url, due to the implementation's dependence on there being more than one query parameter in urls.

### Test Plan
Run `pytest` and `mypy`

Run a dummy script that actually exercises the api:
```
#!/usr/bin/env python

from pybuildkite.buildkite import Buildkite
import os

buildkite = Buildkite()
buildkite.set_access_token(os.getenv("BK_TOKEN"))

# Get all running and scheduled builds for a particular pipeline
pipes = buildkite.pipelines().list_pipelines("my-org", 1)

print(pipes)
```