### PR TITLE
Handle status_code 204 responses for non-DELETE methods

### DIFF
--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -72,7 +72,7 @@ class Client(object):
         if with_pagination:
             response = self._get_paginated_response(response)
             return response
-        if method == "DELETE":
+        if method == "DELETE" or response.status_code == 204:
             return response.ok
         if headers.get("Accept") is None or headers.get("Accept") == "application/json":
             return response.json()

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -72,7 +72,8 @@ class Client(object):
         if with_pagination:
             response = self._get_paginated_response(response)
             return response
-        if method == "DELETE" or response.status_code == 204:
+        if (method == "DELETE" or response.status_code == 204 or
+                response.headers.get('content-type') is None):
             return response.ok
         if headers.get("Accept") is None or headers.get("Accept") == "application/json":
             return response.json()


### PR DESCRIPTION
Thanks for the great library! It looks like stopping an agent (https://buildkite.com/docs/apis/rest-api/agents#stop-an-agent) is a PUT request that returns a 204 which the client tries to handle by parsing the response body as json. Since there's no response body, that'll raise a `JSONDecodeError` exception.