### PR TITLE
Rework artifact download

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A [Python](https://www.python.org/) library and client for the [Buildkite API](https://buildkite.com/docs/api).
 
 
-# Usage
+## Usage
 
 To get the package, execute:
 
@@ -45,7 +45,32 @@ while builds_response.next_page:
     builds_response = buildkite.builds().list_all(page=builds_response.next_page, with_pagination=True)
 ```
 
+## Artifacts
 
-# License
+Artifacts can be downloaded as binary data. The following example loads the artifact into memory as
+[Python bytes](https://docs.python.org/3/library/stdtypes.html#binary-sequence-types-bytes-bytearray-memoryview)
+and then writes them to disc:
+
+```python
+artifacts = buildkite.artifacts()
+artifact = artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact")
+with open('artifact.bin', 'b') as f:
+  f.write(artifact)
+```
+
+Large artifacts should be streamed as chunks of bytes to limit the memory consumption:
+```python
+stream = artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact", as_stream=True)
+with open('artifact.bin', 'b') as f:
+  for chunk in stream:
+    f.write(chunk)
+```
+
+A unicode text artifact can be turned into a string easily:
+```python
+text = str(artifact)
+```
+
+## License
 
 This library is distributed under the BSD-style license found in the LICENSE file.

--- a/pybuildkite/artifacts.py
+++ b/pybuildkite/artifacts.py
@@ -56,18 +56,22 @@ class Artifacts(Client):
         url = self.path + "jobs/{}/artifacts/{}/"
         return self.client.get(url.format(organization, pipeline, build, job, artifact))
 
-    def download_artifact(self, organization, pipeline, build, job, artifact):
+    def download_artifact(self, organization, pipeline, build, job, artifact, as_stream=False):
         """
-        Returns a URL for downloading an artifact.
+        Returns the content of an artifact as bytes.
+
+        With as_stream=True you get an iterator of bytes chunks.
 
         :param organization: organization slug
         :param pipeline: pipeline slug
         :param build: build number
         :param job: job id
         :param artifact: artifact id
-        :return: Returns a URL for downloading an artifact.
+        :param as_stream: stream the artifact content
+        :return: Returns the content of an artifact.
         """
+        headers = {"Accept": "application/octet-stream"}
         url = self.path + "jobs/{}/artifacts/{}/download/"
-        return self.client.get(url.format(organization, pipeline, build, job, artifact))
+        return self.client.get(url.format(organization, pipeline, build, job, artifact), headers=headers, as_stream=as_stream)
 
     # TODO Delete artifact

--- a/pybuildkite/artifacts.py
+++ b/pybuildkite/artifacts.py
@@ -56,7 +56,9 @@ class Artifacts(Client):
         url = self.path + "jobs/{}/artifacts/{}/"
         return self.client.get(url.format(organization, pipeline, build, job, artifact))
 
-    def download_artifact(self, organization, pipeline, build, job, artifact, as_stream=False):
+    def download_artifact(
+        self, organization, pipeline, build, job, artifact, as_stream=False
+    ):
         """
         Returns the content of an artifact as bytes.
 
@@ -72,6 +74,10 @@ class Artifacts(Client):
         """
         headers = {"Accept": "application/octet-stream"}
         url = self.path + "jobs/{}/artifacts/{}/download/"
-        return self.client.get(url.format(organization, pipeline, build, job, artifact), headers=headers, as_stream=as_stream)
+        return self.client.get(
+            url.format(organization, pipeline, build, job, artifact),
+            headers=headers,
+            as_stream=as_stream,
+        )
 
     # TODO Delete artifact

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -71,7 +71,12 @@ class Client(object):
 
         query_params = self._convert_query_params_to_string_for_bytes(query_params)
         response = requests.request(
-            method, url, headers=headers, params=str.encode(query_params), json=body, stream=as_stream
+            method,
+            url,
+            headers=headers,
+            params=str.encode(query_params),
+            json=body,
+            stream=as_stream,
         )
 
         response.raise_for_status()
@@ -102,7 +107,9 @@ class Client(object):
         response_object.append_pagination_data(response.headers)
         return response_object
 
-    def get(self, url, query_params=None, headers={}, with_pagination=False, as_stream=False):
+    def get(
+        self, url, query_params=None, headers={}, with_pagination=False, as_stream=False
+    ):
         """
         Make a GET request to the API
 
@@ -121,7 +128,7 @@ class Client(object):
             query_params=query_params,
             headers=headers,
             with_pagination=with_pagination,
-            as_stream=as_stream
+            as_stream=as_stream,
         )
 
     def post(self, url, body=None, headers={}, query_params=None):

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -36,11 +36,17 @@ class Client(object):
         body=None,
         headers={},
         with_pagination=False,
+        as_stream=False,
     ):
         """
         Make a request to the API
 
-        The request will be authorised if the access token is set
+        The request will be authorised if the access token is set.
+
+        With no accept header set or if set to "application/json",
+        the response will be parsed as Json and returned as a dict.
+        With any other accept header, the response will be returned as bytes.
+        With as_stream=True you will get an iterator of bytes chunks instead.
 
         :param method: HTTP method to use
         :param url: URL to call
@@ -48,7 +54,8 @@ class Client(object):
         :param body: Body of the request
         :param headers: Dictionary of headers to use in HTTP request
         :param with_pagination: Bool to return a response with pagination attributes
-        :return: If headers are set response text is returned, otherwise parsed response is returned
+        :param as_stream: Bool to stream the bytes response
+        :return: response return as parsed json, bytes or bytes chunks iterator
         """
         if headers is None:
             raise ValueError("headers cannot be None")
@@ -64,7 +71,7 @@ class Client(object):
 
         query_params = self._convert_query_params_to_string_for_bytes(query_params)
         response = requests.request(
-            method, url, headers=headers, params=str.encode(query_params), json=body
+            method, url, headers=headers, params=str.encode(query_params), json=body, stream=as_stream
         )
 
         response.raise_for_status()
@@ -80,8 +87,10 @@ class Client(object):
             return response.ok
         if headers.get("Accept") is None or headers.get("Accept") == "application/json":
             return response.json()
+        elif as_stream:
+            return response.iter_content(chunk_size=None, decode_unicode=False)
         else:
-            return response.text
+            return response.content
 
     def _get_paginated_response(self, response):
         """
@@ -93,7 +102,7 @@ class Client(object):
         response_object.append_pagination_data(response.headers)
         return response_object
 
-    def get(self, url, query_params=None, headers={}, with_pagination=False):
+    def get(self, url, query_params=None, headers={}, with_pagination=False, as_stream=False):
         """
         Make a GET request to the API
 
@@ -103,6 +112,7 @@ class Client(object):
         :param query_params: Query parameters to append to URL
         :param headers: Dictionary of headers to use in HTTP request
         :param with_pagination: Bool to return a response with pagination attributes
+        :param as_stream: Bool to stream the response
         :return: If headers are set response text is returned, otherwise parsed response is returned
         """
         return self.request(
@@ -111,6 +121,7 @@ class Client(object):
             query_params=query_params,
             headers=headers,
             with_pagination=with_pagination,
+            as_stream=as_stream
         )
 
     def post(self, url, body=None, headers={}, query_params=None):

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -40,4 +40,14 @@ def test_download_artifact(fake_client):
     artifacts = Artifacts(fake_client, "base")
     artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact")
     url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/artifacts/artifact/download/"
-    fake_client.get.assert_called_with(url)
+    fake_client.get.assert_called_with(url, headers={"Accept": "application/octet-stream"}, as_stream=False)
+
+
+def test_download_artifact_as_stream(fake_client):
+    """
+    Test download Artifact as stream
+    """
+    artifacts = Artifacts(fake_client, "base")
+    artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact", as_stream=True)
+    url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/artifacts/artifact/download/"
+    fake_client.get.assert_called_with(url, headers={"Accept": "application/octet-stream"}, as_stream=True)


### PR DESCRIPTION
This changes the way artifacts are downloaded:
* Always returns bytes, not unicode text or parsed Json
* Can return iterator of bytes chunks to stream artifact over HTTP

Artifacts can be of arbitrary mime type, but currently they are always parsed as JSON, which fails for everything but JSON artifacts. Artifacts should be downloaded as bytes, where user code can than treat those bytes as desired, e.g.: `json.loads(str(the_bytes))`.

The `client.get` method currently only returns either parsed JSON or unicode text, so this has to be touched as well. Encoding the retrieved bytes as unicode as a default for any non `application/json` mime type is quite a hard assumption, and even if type is `text/*` this could be encode in so many other ways. Again, user code can easily decode the bytes as required. So I think bytes is a good default return type for `client.get` if `Accept` is something other than `application/json`.

Finally, since `requests` supports HTTP streaming, the artifact content can easily be streamed to user code as well (e.g. to write that to disk). With streaming, memory footprint stays low and independent of the size of the downloaded artifact.

Artifact content can be consumed like:

If artifact is unicode:
```python
    artifact = artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact")
    str(artifact)
```

If artifact is json:
```python
    artifact = artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact")
    json.loads(str(artifact))
```

Byte content of artifact:
```python
    artifact = artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact")
    with open('artifact.bin', 'b') as f:
      f.write(artifact)
```

Streaming artifact:
```python
    artifact = artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact", as_stream=True)
    with open('artifact.bin', 'b') as f:
      for chunk in artifact:
        f.write(chunk)
```