### PR TITLE
Add patch call to allow pipeline updates

### DIFF
--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -183,7 +183,17 @@ class Client(object):
         )
 
     def patch(self, url, body=None, headers={}, query_params=None):
-        """"""
+        """
+        Make a PATCH request to the API
+
+        The request will be authorised if the access token is set
+
+        :param url: URL to call
+        :param body: Body of the request
+        :param query_params: Query parameters to append to URL
+        :param headers: Dictionary of headers to use in HTTP request
+        :return: If headers are set response text is returned, otherwise parsed response is returned
+        """
         return self.request(
             "PATCH", url=url, query_params=query_params, body=body, headers=headers
         )

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -182,6 +182,13 @@ class Client(object):
             "DELETE", url=url, query_params=query_params, body=body, headers=headers
         )
 
+    def patch(self, url, body=None, headers={}, query_params=None):
+        """
+        """
+        return self.request(
+            "PATCH", url=url, query_params=query_params, body=body, headers=headers
+        )
+
     @staticmethod
     def _clean_query_params(query_params):
         """

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -183,8 +183,7 @@ class Client(object):
         )
 
     def patch(self, url, body=None, headers={}, query_params=None):
-        """
-        """
+        """"""
         return self.request(
             "PATCH", url=url, query_params=query_params, body=body, headers=headers
         )

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -82,7 +82,7 @@ class Jobs(Client):
     def unblock_job(self, organization, pipeline, build, job, fields, unblocker=None):
         """
         Unblocks a build’s "Block pipeline" job.
-         :param organization: Organization slug
+        :param organization: Organization slug
         :param pipeline: Pipeline slug
         :param build: Build number
         :param job: Job id

--- a/pybuildkite/jobs.py
+++ b/pybuildkite/jobs.py
@@ -81,14 +81,14 @@ class Jobs(Client):
 
     def unblock_job(self, organization, pipeline, build, job, fields, unblocker=None):
         """
-           Unblocks a build’s "Block pipeline" job.
-            :param organization: Organization slug
-           :param pipeline: Pipeline slug
-           :param build: Build number
-           :param job: Job id
-           :fields: name and email
-           :unblocker: The user id of the person activating the job
-           :return: response
+        Unblocks a build’s "Block pipeline" job.
+         :param organization: Organization slug
+        :param pipeline: Pipeline slug
+        :param build: Build number
+        :param job: Job id
+        :fields: name and email
+        :unblocker: The user id of the person activating the job
+        :return: response
         """
         unblock = "/unblock"
         body = {"fields": fields, "unblocker": unblocker}

--- a/pybuildkite/organizations.py
+++ b/pybuildkite/organizations.py
@@ -19,7 +19,7 @@ class Organizations(Client):
     def list_all(self, page=0, with_pagination=False):
         """
         Returns a paginated list of the user’s organizations.
-        
+
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
         :return: Paginated list of the user’s organizations.

--- a/pybuildkite/pipelines.py
+++ b/pybuildkite/pipelines.py
@@ -85,11 +85,47 @@ class Pipelines(Client):
         url = self.path.format(organization) + pipeline
         return self.client.delete(url)
 
-    def update_pipeline(self, organization, pipeline):
+    def update_pipeline(
+        self,
+        organization,
+        pipeline,
+        branch_configuration: str = None,
+        cancel_running_branch_builds: bool = None,
+        cancel_running_branch_builds_filter: str = None,
+        default_branch: str = None,
+        description: str = None,
+        env: dict = None,
+        name: str = None,
+        provider_settings: dict = None,
+        repository: str = None,
+        steps: dict = None,
+        skip_queued_branch_builds: bool = None,
+        skip_queued_branch_builds_filter: str = None,
+        visibility: str = None,
+    ):
         """
+        Patch a pipeline. 
+        See https://buildkite.com/docs/apis/rest-api/pipelines#update-a-pipeline 
+        for documentation on each input
+
+        :param organization: Organization slug
+        :param pipeline: Pipeline slug
+        :return: Pipeline
         """
         body = {
-            "description": "'CI Pipeline for the PyBuildkite wrapper"
+            "branch_configuration": branch_configuration,
+            "cancel_running_branch_builds": cancel_running_branch_builds,
+            "cancel_running_branch_builds_filter": cancel_running_branch_builds_filter,
+            "default_branch": default_branch,
+            "description": description,
+            "env": env,
+            "name": name,
+            "provider_settings": provider_settings,
+            "repository": repository,
+            "steps": steps,
+            "skip_queued_branch_builds": skip_queued_branch_builds,
+            "skip_queued_branch_builds_filter": skip_queued_branch_builds_filter,
+            "visibility": visibility,
         }
         url = self.path.format(organization) + pipeline
         return self.client.patch(url, body=body)

--- a/pybuildkite/pipelines.py
+++ b/pybuildkite/pipelines.py
@@ -84,3 +84,12 @@ class Pipelines(Client):
         """
         url = self.path.format(organization) + pipeline
         return self.client.delete(url)
+
+    def update_pipeline(self, organization, pipeline):
+        """
+        """
+        body = {
+            "description": "'CI Pipeline for the PyBuildkite wrapper"
+        }
+        url = self.path.format(organization) + pipeline
+        return self.client.patch(url, body=body)

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -40,7 +40,9 @@ def test_download_artifact(fake_client):
     artifacts = Artifacts(fake_client, "base")
     artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact")
     url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/artifacts/artifact/download/"
-    fake_client.get.assert_called_with(url, headers={"Accept": "application/octet-stream"}, as_stream=False)
+    fake_client.get.assert_called_with(
+        url, headers={"Accept": "application/octet-stream"}, as_stream=False
+    )
 
 
 def test_download_artifact_as_stream(fake_client):
@@ -48,6 +50,10 @@ def test_download_artifact_as_stream(fake_client):
     Test download Artifact as stream
     """
     artifacts = Artifacts(fake_client, "base")
-    artifacts.download_artifact("org_slug", "pipe_slug", "build_no", 123, "artifact", as_stream=True)
+    artifacts.download_artifact(
+        "org_slug", "pipe_slug", "build_no", 123, "artifact", as_stream=True
+    )
     url = "base/organizations/org_slug/pipelines/pipe_slug/builds/build_no/jobs/123/artifacts/artifact/download/"
-    fake_client.get.assert_called_with(url, headers={"Accept": "application/octet-stream"}, as_stream=True)
+    fake_client.get.assert_called_with(
+        url, headers={"Accept": "application/octet-stream"}, as_stream=True
+    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -139,7 +139,11 @@ class TestClientRequest:
         fake_client = Client()
 
         with patch("requests.request") as request:
-            request.return_value.iter_content.return_value = [b"response", b" ", b"text"]
+            request.return_value.iter_content.return_value = [
+                b"response",
+                b" ",
+                b"text",
+            ]
 
             resp = fake_client.request(
                 "GET",
@@ -173,7 +177,9 @@ class TestClientRequest:
         with patch("requests.request") as request:
             request.return_value.json.return_value = {"key": "value"}
 
-            resp = fake_client.request("GET", "http://www.google.com/", headers={"Accept": "application/json"})
+            resp = fake_client.request(
+                "GET", "http://www.google.com/", headers={"Accept": "application/json"}
+            )
 
         expected_params = b"per_page=100"
         request.assert_called_once_with(

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -61,3 +61,32 @@ def test_delete_pipeline(fake_client):
     fake_client.delete.assert_called_with(
         pipeline.path.format("test_org") + "test_pipeline"
     )
+
+
+def test_update_pipeline(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.update_pipeline(
+        "test_org",
+        "test_pipeline",
+        name="Name Change Test",
+        env={"TEST_ENV_VAR": "VALUE"},
+        skip_queued_branch_builds=True,
+    )
+    fake_client.patch.assert_called_with(
+        pipeline.path.format("test_org") + "test_pipeline",
+        body={
+            "branch_configuration": None,
+            "cancel_running_branch_builds": None,
+            "cancel_running_branch_builds_filter": None,
+            "default_branch": None,
+            "description": None,
+            "env": {"TEST_ENV_VAR": "VALUE"},
+            "name": "Name Change Test",
+            "provider_settings": None,
+            "repository": None,
+            "steps": None,
+            "skip_queued_branch_builds": True,
+            "skip_queued_branch_builds_filter": None,
+            "visibility": None,
+        },
+    )


### PR DESCRIPTION
# Add PATCH functionality

Adding to PATCH functionality to the client so that we can utilize the REST api's ability to update pipelines as seen [here](https://buildkite.com/docs/apis/rest-api/pipelines#update-a-pipeline).

This addresses #54 