### PR TITLE
Allow to get builds with retried jobs

### DIFF
--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -109,9 +109,12 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
-            "include_retried_jobs": include_retried_jobs,
             "page": page,
         }
+
+        if include_retried_jobs:
+            query_params.update(include_retried_jobs=include_retried_jobs)
+
         query_params.update(self.__process_meta_data(meta_data))
 
         return self.client.get(
@@ -164,9 +167,12 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
-            "include_retried_jobs": include_retried_jobs,
             "page": page,
         }
+
+        if include_retried_jobs:
+            query_params.update(include_retried_jobs=include_retried_jobs)
+
         query_params.update(self.__process_meta_data(meta_data))
 
         return self.client.get(
@@ -223,9 +229,12 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
-            "include_retried_jobs": include_retried_jobs,
             "page": page,
         }
+
+        if include_retried_jobs:
+            query_params.update(include_retried_jobs=include_retried_jobs)
+
         query_params.update(self.__process_meta_data(meta_data))
 
         return self.client.get(
@@ -247,7 +256,10 @@ class Builds(Client):
                Without this parameter, you'll see only the most recently run job for each step.
         :return: A build
         """
-        query_params = {"include_retried_jobs": include_retried_jobs}
+        query_params = {}
+        if include_retried_jobs:
+            query_params.update(include_retried_jobs=include_retried_jobs)
+
         return self.client.get(
             self.path_for_build_number.format(organization, pipeline, build_number),
             query_params=query_params,

--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -248,7 +248,7 @@ class Builds(Client):
         :return: A build
         """
         query_params = {
-            "include_retried_jobs": True if include_retried_jobs is True else None,
+            "include_retried_jobs": True if include_retried_jobs is True else None
         }
         return self.client.get(
             self.path_for_build_number.format(organization, pipeline, build_number),

--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -75,6 +75,7 @@ class Builds(Client):
         meta_data=None,
         branch=None,
         commit=None,
+        include_retried_jobs=False,
         page=0,
         with_pagination=False,
     ):
@@ -91,6 +92,8 @@ class Builds(Client):
         :param meta_data: Filters the results by the given meta_data. Example: ?meta_data[some-key]=some-value
         :param branch: Filters the results by the given branch or branches.
         :param commit: Filters the results by the commit (only works for full sha, not for shortened ones).
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+               Without this parameter, you'll see only the most recently run job for each step.
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
         :return: Returns a paginated list of all builds across all the user’s organizations and pipelines
@@ -106,6 +109,7 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
+            "include_retried_jobs": include_retried_jobs,
             "page": page,
         }
         query_params.update(self.__process_meta_data(meta_data))
@@ -125,6 +129,7 @@ class Builds(Client):
         meta_data=None,
         branch=None,
         commit=None,
+        include_retried_jobs=False,
         page=0,
         with_pagination=False,
     ):
@@ -141,6 +146,8 @@ class Builds(Client):
         :param meta_data: Filters the results by the given meta_data.
         :param branch: Filters the results by the given branch or branches.
         :param commit: Filters the results by the commit (only works for full sha, not for shortened ones).
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+               Without this parameter, you'll see only the most recently run job for each step.
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
         :return: Returns a paginated list of an organization’s builds across all of an organization’s pipelines.
@@ -157,6 +164,7 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
+            "include_retried_jobs": include_retried_jobs,
             "page": page,
         }
         query_params.update(self.__process_meta_data(meta_data))
@@ -179,6 +187,7 @@ class Builds(Client):
         meta_data=None,
         branch=None,
         commit=None,
+        include_retried_jobs=False,
         page=0,
         with_pagination=False,
     ):
@@ -196,6 +205,8 @@ class Builds(Client):
         :param meta_data: Filters the results by the given meta_data.
         :param branch: Filters the results by the given branch or branches.
         :param commit: Filters the results by the commit (only works for full sha, not for shortened ones).
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+               Without this parameter, you'll see only the most recently run job for each step.
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
         :return: Returns a paginated list of a pipeline’s builds.
@@ -212,6 +223,7 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
+            "include_retried_jobs": include_retried_jobs,
             "page": page,
         }
         query_params.update(self.__process_meta_data(meta_data))
@@ -222,17 +234,23 @@ class Builds(Client):
             with_pagination=with_pagination,
         )
 
-    def get_build_by_number(self, organization, pipeline, build_number):
+    def get_build_by_number(
+        self, organization, pipeline, build_number, include_retried_jobs=False
+    ):
         """
         Get build by build number
 
         :param organization: Organization slug
         :param pipeline: Pipeline slug
         :param build_number: Build number
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+               Without this parameter, you'll see only the most recently run job for each step.
         :return: A build
         """
+        query_params = {"include_retried_jobs": include_retried_jobs}
         return self.client.get(
-            self.path_for_build_number.format(organization, pipeline, build_number)
+            self.path_for_build_number.format(organization, pipeline, build_number),
+            query_params=query_params,
         )
 
     def create_build(

--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -75,7 +75,7 @@ class Builds(Client):
         meta_data=None,
         branch=None,
         commit=None,
-        include_retried_jobs=False,
+        include_retried_jobs=None,
         page=0,
         with_pagination=False,
     ):
@@ -92,7 +92,7 @@ class Builds(Client):
         :param meta_data: Filters the results by the given meta_data. Example: ?meta_data[some-key]=some-value
         :param branch: Filters the results by the given branch or branches.
         :param commit: Filters the results by the commit (only works for full sha, not for shortened ones).
-        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list if True.
                Without this parameter, you'll see only the most recently run job for each step.
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
@@ -109,12 +109,9 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
+            "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
         }
-
-        if include_retried_jobs:
-            query_params.update(include_retried_jobs=include_retried_jobs)
-
         query_params.update(self.__process_meta_data(meta_data))
 
         return self.client.get(
@@ -132,7 +129,7 @@ class Builds(Client):
         meta_data=None,
         branch=None,
         commit=None,
-        include_retried_jobs=False,
+        include_retried_jobs=None,
         page=0,
         with_pagination=False,
     ):
@@ -149,7 +146,7 @@ class Builds(Client):
         :param meta_data: Filters the results by the given meta_data.
         :param branch: Filters the results by the given branch or branches.
         :param commit: Filters the results by the commit (only works for full sha, not for shortened ones).
-        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list if True.
                Without this parameter, you'll see only the most recently run job for each step.
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
@@ -167,12 +164,9 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
+            "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
         }
-
-        if include_retried_jobs:
-            query_params.update(include_retried_jobs=include_retried_jobs)
-
         query_params.update(self.__process_meta_data(meta_data))
 
         return self.client.get(
@@ -193,7 +187,7 @@ class Builds(Client):
         meta_data=None,
         branch=None,
         commit=None,
-        include_retried_jobs=False,
+        include_retried_jobs=None,
         page=0,
         with_pagination=False,
     ):
@@ -211,7 +205,7 @@ class Builds(Client):
         :param meta_data: Filters the results by the given meta_data.
         :param branch: Filters the results by the given branch or branches.
         :param commit: Filters the results by the commit (only works for full sha, not for shortened ones).
-        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list if True.
                Without this parameter, you'll see only the most recently run job for each step.
         :param page: Int to determine which page to read from (See Pagination in README)
         :param with_pagination: Bool to return a response with pagination attributes
@@ -229,12 +223,9 @@ class Builds(Client):
             "state": self.__get_build_states_query_param(states),
             "branch": branch,
             "commit": commit,
+            "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
         }
-
-        if include_retried_jobs:
-            query_params.update(include_retried_jobs=include_retried_jobs)
-
         query_params.update(self.__process_meta_data(meta_data))
 
         return self.client.get(
@@ -244,7 +235,7 @@ class Builds(Client):
         )
 
     def get_build_by_number(
-        self, organization, pipeline, build_number, include_retried_jobs=False
+        self, organization, pipeline, build_number, include_retried_jobs=None
     ):
         """
         Get build by build number
@@ -252,14 +243,13 @@ class Builds(Client):
         :param organization: Organization slug
         :param pipeline: Pipeline slug
         :param build_number: Build number
-        :param include_retried_jobs: Include all retried job executions in each build’s jobs list.
+        :param include_retried_jobs: Include all retried job executions in each build’s jobs list if True.
                Without this parameter, you'll see only the most recently run job for each step.
         :return: A build
         """
-        query_params = {}
-        if include_retried_jobs:
-            query_params.update(include_retried_jobs=include_retried_jobs)
-
+        query_params = {
+            "include_retried_jobs": True if include_retried_jobs is True else None,
+        }
         return self.client.get(
             self.path_for_build_number.format(organization, pipeline, build_number),
             query_params=query_params,

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -23,6 +23,7 @@ def test_list_all_builds_single_build_state(fake_client):
             "state": "state=running",
             "branch": None,
             "commit": None,
+            "include_retried_jobs": None,
             "page": 0,
         },
         with_pagination=False,
@@ -42,6 +43,7 @@ def test_list_all_builds_multiple_build_states(fake_client):
             "state": "state[]=running&state[]=finished",
             "branch": None,
             "commit": None,
+            "include_retried_jobs": None,
             "page": 0,
         },
         with_pagination=False,
@@ -79,6 +81,7 @@ def test_list_all_builds_for_org(fake_client):
             "state": None,
             "branch": None,
             "commit": None,
+            "include_retried_jobs": None,
             "page": 0,
         },
         with_pagination=False,
@@ -98,6 +101,7 @@ def test_list_all_for_pipeline(fake_client):
             "state": None,
             "branch": None,
             "commit": None,
+            "include_retried_jobs": None,
             "page": 0,
         },
         with_pagination=False,
@@ -109,7 +113,7 @@ def test_get_build_by_number(fake_client):
     builds.get_build_by_number("org_slug", "pipeline_id", "build_number")
     fake_client.get.assert_called_with(
         builds.path_for_build_number.format("org_slug", "pipeline_id", "build_number"),
-        query_params={},
+        query_params={"include_retried_jobs": None},
     )
 
 

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -23,7 +23,6 @@ def test_list_all_builds_single_build_state(fake_client):
             "state": "state=running",
             "branch": None,
             "commit": None,
-            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -43,7 +42,6 @@ def test_list_all_builds_multiple_build_states(fake_client):
             "state": "state[]=running&state[]=finished",
             "branch": None,
             "commit": None,
-            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -81,7 +79,6 @@ def test_list_all_builds_for_org(fake_client):
             "state": None,
             "branch": None,
             "commit": None,
-            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -101,7 +98,6 @@ def test_list_all_for_pipeline(fake_client):
             "state": None,
             "branch": None,
             "commit": None,
-            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -113,7 +109,7 @@ def test_get_build_by_number(fake_client):
     builds.get_build_by_number("org_slug", "pipeline_id", "build_number")
     fake_client.get.assert_called_with(
         builds.path_for_build_number.format("org_slug", "pipeline_id", "build_number"),
-        query_params={"include_retried_jobs": False},
+        query_params={},
     )
 
 

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -23,6 +23,7 @@ def test_list_all_builds_single_build_state(fake_client):
             "state": "state=running",
             "branch": None,
             "commit": None,
+            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -42,6 +43,7 @@ def test_list_all_builds_multiple_build_states(fake_client):
             "state": "state[]=running&state[]=finished",
             "branch": None,
             "commit": None,
+            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -79,6 +81,7 @@ def test_list_all_builds_for_org(fake_client):
             "state": None,
             "branch": None,
             "commit": None,
+            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -98,6 +101,7 @@ def test_list_all_for_pipeline(fake_client):
             "state": None,
             "branch": None,
             "commit": None,
+            "include_retried_jobs": False,
             "page": 0,
         },
         with_pagination=False,
@@ -108,7 +112,19 @@ def test_get_build_by_number(fake_client):
     builds = Builds(fake_client, "https://api.buildkite.com/v2/")
     builds.get_build_by_number("org_slug", "pipeline_id", "build_number")
     fake_client.get.assert_called_with(
-        builds.path_for_build_number.format("org_slug", "pipeline_id", "build_number")
+        builds.path_for_build_number.format("org_slug", "pipeline_id", "build_number"),
+        query_params={"include_retried_jobs": False},
+    )
+
+
+def test_get_build_by_number_with_retried_jobs(fake_client):
+    builds = Builds(fake_client, "https://api.buildkite.com/v2/")
+    builds.get_build_by_number(
+        "org_slug", "pipeline_id", "build_number", include_retried_jobs=True
+    )
+    fake_client.get.assert_called_with(
+        builds.path_for_build_number.format("org_slug", "pipeline_id", "build_number"),
+        query_params={"include_retried_jobs": True},
     )
 
 


### PR DESCRIPTION
This flag is not documented (see https://github.com/buildkite/docs/pull/823), but it works perfectly.