### PR TITLE
Add optional team_uuids param

### DIFF
--- a/pybuildkite/pipelines.py
+++ b/pybuildkite/pipelines.py
@@ -54,6 +54,7 @@ class Pipelines(Client):
                 command="buildkite-agent pipeline upload",
             )
         ],
+        team_uuids: list = None,
     ):
         """
         Create a pipeline for organizations using Web Visual Steps. 
@@ -66,12 +67,14 @@ class Pipelines(Client):
         :param organization: Organization slug
         :param pipeline_name:Pipeline slug
         :param git_repository: repo URL
+        :param team_uuids: A list of team_uuids. This property is only available if your organization has enabled Teams.
         :return:
         """
         data = {
             "name": pipeline_name,
             "repository": git_repository,
             "steps": build_steps,
+            "team_uuids": team_uuids,
         }
 
         return self.client.post(self.path.format(organization), body=data)
@@ -81,7 +84,8 @@ class Pipelines(Client):
         organization,
         pipeline_name,
         git_repository,
-        configuration
+        configuration,
+        team_uuids: list = None,
     ):
         """
         Create a pipeline for organizations who have migrated to YAML pipelines
@@ -90,12 +94,14 @@ class Pipelines(Client):
         :param pipeline_name:Pipeline slug
         :param git_repository: repo URL
         :param configuration: a valid pipeline.yml
+        :param team_uuids: A list of team_uuids. This property is only available if your organization has enabled Teams.
         :return:
         """
         data = {
             "name": pipeline_name,
             "repository": git_repository,
             "configuration": configuration,
+            "team_uuids": team_uuids,
         }
         return self.client.post(self.path.format(organization), body=data)
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -55,6 +55,28 @@ def test_create_pipeline(fake_client):
     )
 
 
+def test_create_pipeline_with_teams(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_pipeline("test_org", "test_pipeline", "my_repo", team_uuids=["123"])
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "steps": [
+                {
+                    "type": "script",
+                    "name": ":pipeline:",
+                    "command": "buildkite-agent pipeline upload",
+                }
+            ],
+            "team_uuids": [
+                "123"
+            ]
+        }
+    )
+
+
 def test_create_yaml_pipeline(fake_client):
     pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
     pipeline.create_yaml_pipeline("test_org", "test_pipeline", "my_repo", "steps:\n  - command: ls")
@@ -64,6 +86,22 @@ def test_create_yaml_pipeline(fake_client):
             "name": "test_pipeline",
             "repository": "my_repo",
             "configuration": "steps:\n  - command: ls",
+        },
+    )
+
+
+def test_create_yaml_pipeline_with_teams(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_yaml_pipeline("test_org", "test_pipeline", "my_repo", "steps:\n  - command: ls", team_uuids=["123"])
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "configuration": "steps:\n  - command: ls",
+            "team_uuids": [
+                "123"
+            ]
         },
     )
 


### PR DESCRIPTION
# Summary

This adds `team_uuids` optional parameter to `create_yaml_pipeline`. For our organisation, teams are mandatory for pipeline creation, and when omitted will result in:
```json
{"message":"Validation Failed","errors":[{"field":"teams","code":"Please ensure at least one team is added to this pipeline","value":[]}]}
``` 