### PR TITLE
Add `meta` endpoint functionality

### DIFF
--- a/pybuildkite/buildkite.py
+++ b/pybuildkite/buildkite.py
@@ -9,6 +9,7 @@ from pybuildkite.annotations import Annotations
 from pybuildkite.artifacts import Artifacts
 from pybuildkite.teams import Teams
 from pybuildkite.users import Users
+from pybuildkite.meta import Meta
 from pybuildkite.decorators import requires_token
 
 
@@ -110,3 +111,11 @@ class Buildkite(object):
         Get User operations for the Buildkite API
         """
         return Users(self.client, self.base_url)
+
+    def meta(self):
+        """
+        Get Organization operations for the Buildkite API
+
+        :return: Client
+        """
+        return Meta(self.client, self.base_url)

--- a/pybuildkite/buildkite.py
+++ b/pybuildkite/buildkite.py
@@ -114,7 +114,7 @@ class Buildkite(object):
 
     def meta(self):
         """
-        Get Organization operations for the Buildkite API
+        Get Meta operations for the Buildkite API
 
         :return: Client
         """

--- a/pybuildkite/meta.py
+++ b/pybuildkite/meta.py
@@ -1,0 +1,27 @@
+from posixpath import join as urljoin
+
+from pybuildkite.client import Client
+
+
+class Meta(Client):
+    """
+    Meta operations for the Buildkite API
+    """
+
+    def __init__(self, client, base_url):
+        """
+        Construct the class
+
+        :param client: API Client
+        :param base_url: Base Url
+        """
+        self.client = client
+        self.path = urljoin(base_url, "meta")
+
+    def get_meta_information(self):
+        """
+        Returns meta information
+
+        :return: Returns meta information
+        """
+        return self.client.get(self.path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ mock==3.0.5
 coveralls==2.0.0
 pytest==5.2.1
 pytest-cov==2.8.1
-requests==2.22.0
+requests==2.26.0
 urllib3==1.26.5
 black==19.3b0
 typing-extensions==3.7.4.2

--- a/tests/test_buildkite.py
+++ b/tests/test_buildkite.py
@@ -11,6 +11,7 @@ from pybuildkite.buildkite import (
     Teams,
     Users,
     Organizations,
+    Meta,
 )
 from pybuildkite.exceptions import NoAcccessTokenException
 
@@ -46,6 +47,7 @@ def test_access_token_set():
         (Buildkite().users, Users),
         (Buildkite().annotations, Annotations),
         (Buildkite().organizations, Organizations),
+        (Buildkite().meta, Meta),
     ],
 )
 def test_eval(function, expected_type):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,10 @@
+from pybuildkite.meta import Meta
+
+
+def test_get_meta_information(fake_client):
+    """
+    Test get user
+    """
+    meta = Meta(fake_client, "https://api.buildkite.com/v2/")
+    meta.get_meta_information()
+    fake_client.get.assert_called_with(meta.path)

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -51,6 +51,7 @@ def test_create_pipeline(fake_client):
                     "command": "buildkite-agent pipeline upload",
                 }
             ],
+            "team_uuids": None,
         }
     )
 
@@ -86,6 +87,7 @@ def test_create_yaml_pipeline(fake_client):
             "name": "test_pipeline",
             "repository": "my_repo",
             "configuration": "steps:\n  - command: ls",
+            "team_uuids": None,
         },
     )
 


### PR DESCRIPTION
## Issue

Closes #66 

## What I did

- [x] Implemented a new `Meta` class in `meta.py` to handle the [Meta API](https://buildkite.com/docs/apis/rest-api/meta)
- [x] Instanced the `Meta` class in `buildkit.py`
- [x] Added tests to ensure that the new class is working as expected
  - Also: tested locally that the `Meta` class works properly without authentication and returns the `webhook_ips`
- [x] Fixed two tests that were failing on `test_pipelines.py` after changes to the call format
- [x] Bumped `requests` to version `2.26.0` to solve a dependency conflict with `urllib3`

## How to test

Run all unit tests with `pytest`, they should pass properly.

You can also test manually by running:

```python3
from pybuildkite import buildkite

bk = buildkite.Buildkite()
meta_information = bk.meta().get_meta_information()

# `meta_information` should be a `dict` instance similar to:
# {'webhook_ips': ['100.24.182.113', '35.172.45.249', '54.85.125.32']}
```  