### PR TITLE
more mypy default options

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,10 @@
 [mypy]
 ignore_missing_imports = True
+disallow_any_unimported = True
+check_untyped_defs = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_ignores = True
+warn_unused_configs = True
+show_error_codes = True
+pretty = True


### PR DESCRIPTION
Just a suggestion. These are most of the rules I rules personally. IIRC, they're originally from something like https://blog.wolt.com/engineering/2021/09/30/professional-grade-mypy-configuration/.

I also personally use `disallow_untyped_defs = True` and `no_implicit_optional = True`, but they required code changes to enforce. If interested, can help enable them as well.