### PR TITLE
Add more options for when creating pipelines

### DIFF
--- a/pybuildkite/pipelines.py
+++ b/pybuildkite/pipelines.py
@@ -55,6 +55,9 @@ class Pipelines(Client):
             )
         ],
         team_uuids: list = None,
+        branch_configuration: str = None,
+        default_branch: str = None,
+        provider_settings: dict = None,
     ):
         """
         Create a pipeline for organizations using Web Visual Steps.
@@ -68,6 +71,9 @@ class Pipelines(Client):
         :param pipeline_name:Pipeline slug
         :param git_repository: repo URL
         :param team_uuids: A list of team_uuids. This property is only available if your organization has enabled Teams.
+        :param branch_configuration: A branch filter pattern to limit which pushed branches or tags trigger builds on this pipeline.
+        :param default_branch: The name of the default branch in the repository you've specified.
+        :param provider_settings: A dictionary of provider-specific settings to configure.
         :return:
         """
         data = {
@@ -75,6 +81,9 @@ class Pipelines(Client):
             "repository": git_repository,
             "steps": build_steps,
             "team_uuids": team_uuids,
+            "branch_configuration": branch_configuration,
+            "default_branch": default_branch,
+            "provider_settings": provider_settings,
         }
 
         return self.client.post(self.path.format(organization), body=data)
@@ -86,6 +95,9 @@ class Pipelines(Client):
         git_repository,
         configuration,
         team_uuids: list = None,
+        branch_configuration: str = None,
+        default_branch: str = None,
+        provider_settings: dict = None,
     ):
         """
         Create a pipeline for organizations who have migrated to YAML pipelines
@@ -95,6 +107,9 @@ class Pipelines(Client):
         :param git_repository: repo URL
         :param configuration: a valid pipeline.yml
         :param team_uuids: A list of team_uuids. This property is only available if your organization has enabled Teams.
+        :param branch_configuration: A branch filter pattern to limit which pushed branches or tags trigger builds on this pipeline.
+        :param default_branch: The name of the default branch in the repository you've specified.
+        :param provider_settings: A dictionary of provider-specific settings to configure.
         :return:
         """
         data = {
@@ -102,6 +117,9 @@ class Pipelines(Client):
             "repository": git_repository,
             "configuration": configuration,
             "team_uuids": team_uuids,
+            "branch_configuration": branch_configuration,
+            "default_branch": default_branch,
+            "provider_settings": provider_settings,
         }
         return self.client.post(self.path.format(organization), body=data)
 

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -52,6 +52,9 @@ def test_create_pipeline(fake_client):
                 }
             ],
             "team_uuids": None,
+            "branch_configuration": None,
+            "default_branch": None,
+            "provider_settings": None,
         },
     )
 
@@ -72,6 +75,84 @@ def test_create_pipeline_with_teams(fake_client):
                 }
             ],
             "team_uuids": ["123"],
+            "branch_configuration": None,
+            "default_branch": None,
+            "provider_settings": None,
+        },
+    )
+
+
+def test_create_pipeline_with_branch_configuration(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_pipeline(
+        "test_org", "test_pipeline", "my_repo", branch_configuration="v*"
+    )
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "steps": [
+                {
+                    "type": "script",
+                    "name": ":pipeline:",
+                    "command": "buildkite-agent pipeline upload",
+                }
+            ],
+            "team_uuids": None,
+            "branch_configuration": "v*",
+            "default_branch": None,
+            "provider_settings": None,
+        },
+    )
+
+
+def test_create_pipeline_with_default_branch(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_pipeline(
+        "test_org", "test_pipeline", "my_repo", default_branch="main"
+    )
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "steps": [
+                {
+                    "type": "script",
+                    "name": ":pipeline:",
+                    "command": "buildkite-agent pipeline upload",
+                }
+            ],
+            "team_uuids": None,
+            "branch_configuration": None,
+            "default_branch": "main",
+            "provider_settings": None,
+        },
+    )
+
+
+def test_create_pipeline_with_provider_settings(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_pipeline(
+        "test_org", "test_pipeline", "my_repo", provider_settings={"build_tags": True}
+    )
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "steps": [
+                {
+                    "type": "script",
+                    "name": ":pipeline:",
+                    "command": "buildkite-agent pipeline upload",
+                }
+            ],
+            "team_uuids": None,
+            "branch_configuration": None,
+            "default_branch": None,
+            "provider_settings": {"build_tags": True},
         },
     )
 
@@ -88,6 +169,9 @@ def test_create_yaml_pipeline(fake_client):
             "repository": "my_repo",
             "configuration": "steps:\n  - command: ls",
             "team_uuids": None,
+            "branch_configuration": None,
+            "default_branch": None,
+            "provider_settings": None,
         },
     )
 
@@ -108,6 +192,78 @@ def test_create_yaml_pipeline_with_teams(fake_client):
             "repository": "my_repo",
             "configuration": "steps:\n  - command: ls",
             "team_uuids": ["123"],
+            "branch_configuration": None,
+            "default_branch": None,
+            "provider_settings": None,
+        },
+    )
+
+
+def test_create_yaml_pipeline_with_branch_configuration(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_yaml_pipeline(
+        "test_org",
+        "test_pipeline",
+        "my_repo",
+        "steps:\n  - command: ls",
+        branch_configuration="v*",
+    )
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "configuration": "steps:\n  - command: ls",
+            "team_uuids": None,
+            "branch_configuration": "v*",
+            "default_branch": None,
+            "provider_settings": None,
+        },
+    )
+
+
+def test_create_yaml_pipeline_with_default_branch(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_yaml_pipeline(
+        "test_org",
+        "test_pipeline",
+        "my_repo",
+        "steps:\n  - command: ls",
+        default_branch="main",
+    )
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "configuration": "steps:\n  - command: ls",
+            "team_uuids": None,
+            "branch_configuration": None,
+            "default_branch": "main",
+            "provider_settings": None,
+        },
+    )
+
+
+def test_create_yaml_pipeline_with_provider_settings(fake_client):
+    pipeline = Pipelines(fake_client, "https://api.buildkite.com/v2/")
+    pipeline.create_yaml_pipeline(
+        "test_org",
+        "test_pipeline",
+        "my_repo",
+        "steps:\n  - command: ls",
+        provider_settings={"build_tags": True},
+    )
+    fake_client.post.assert_called_with(
+        pipeline.path.format("test_org"),
+        body={
+            "name": "test_pipeline",
+            "repository": "my_repo",
+            "configuration": "steps:\n  - command: ls",
+            "team_uuids": None,
+            "branch_configuration": None,
+            "default_branch": None,
+            "provider_settings": {"build_tags": True},
         },
     )
 


### PR DESCRIPTION
It's totally valid to pass these options when creating a pipeline. Allowing them to be passed through reduces the need to run a separate update API request after creation.