### PR TITLE
Add "failing" to build state

### DIFF
--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -20,6 +20,7 @@ class BuildState(Enum):
     RUNNING = "running"
     SCHEDULED = "scheduled"
     PASSED = "passed"
+    FAILING = "failing"
     FAILED = "failed"
     BLOCKED = "blocked"
     CANCELED = "canceled"


### PR DESCRIPTION
The valid states for `state` query of the list all builds API includes "failing" state.

https://buildkite.com/docs/apis/rest-api/builds#list-all-builds
> Filters the results by the given [build state](https://buildkite.com/docs/pipelines/notifications#build-states). The finished state is a shortcut to automatically search for builds with passed, failed, blocked, canceled states.
Valid states: running, scheduled, passed, failing, failed, blocked, canceled, canceling, skipped, not_run, finished

This commit adds the "failing" state.