### PR TITLE
Add support for multiple branches in builds API calls

### DIFF
--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -108,7 +108,7 @@ class Builds(Client):
             "created_to": self.__api_date_format(created_to),
             "finished_from": self.__api_date_format(finished_from),
             "state": self.__get_build_states_query_param(states),
-            "branch": branch,
+            "branch": self.__get_branches_query_param(branch),
             "commit": commit,
             "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
@@ -163,7 +163,7 @@ class Builds(Client):
             "created_to": self.__api_date_format(created_to),
             "finished_from": self.__api_date_format(finished_from),
             "state": self.__get_build_states_query_param(states),
-            "branch": branch,
+            "branch": self.__get_branches_query_param(branch),
             "commit": commit,
             "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
@@ -222,7 +222,7 @@ class Builds(Client):
             "created_to": self.__api_date_format(created_to),
             "finished_from": self.__api_date_format(finished_from),
             "state": self.__get_build_states_query_param(states),
-            "branch": branch,
+            "branch": self.__get_branches_query_param(branch),
             "commit": commit,
             "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
@@ -364,3 +364,16 @@ class Builds(Client):
             for state in states:
                 param_string += "state[]={}&".format(state.value)
             return param_string[:-1]
+
+    @staticmethod
+    def __get_branches_query_param(branches):
+        if not branches:
+            return None
+
+        if isinstance(branches, List):
+            param_string = ""
+            for branch in branches:
+                param_string += "branch[]={}&".format(branch)
+            return param_string[:-1]
+        else:
+            return "branch=" + branches

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -221,6 +221,8 @@ class Client(object):
                 query_string += "&"
             if key == "state":
                 query_string += value
+            elif key == "branch":
+                query_string += value
             else:
                 query_string += key + "=" + str(value)
         return query_string

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pytest-cov==2.8.1
 requests==2.26.0
 urllib3==1.26.5
 black==22.6.0
-typing-extensions==3.7.4.2
+typing-extensions==4.5.0
 mypy==0.770
 mypy-extensions==0.4.3

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -216,3 +216,31 @@ def test_rebuild_build(fake_client):
         builds.path_for_build_number.format("org_slug", "pipeline_id", "build_number")
         + "/rebuild"
     )
+
+
+def test_multi_branch(fake_client):
+    builds = Builds(fake_client, "https://api.buildkite.com/v2/")
+    builds.rebuild_build("org_slug", "pipeline_id", "build_number")
+
+    builds.list_all_for_pipeline(
+        organization="org",
+        pipeline="pipe",
+        branch=["main", "master"]
+    )
+
+    args = fake_client.get.call_args[0][1]
+    assert args["branch"] == "branch[]=main&branch[]=master"
+
+
+def test_single_branch(fake_client):
+    builds = Builds(fake_client, "https://api.buildkite.com/v2/")
+    builds.rebuild_build("org_slug", "pipeline_id", "build_number")
+
+    builds.list_all_for_pipeline(
+        organization="org",
+        pipeline="pipe",
+        branch="main"
+    )
+
+    args = fake_client.get.call_args[0][1]
+    assert args["branch"] == "branch=main"


### PR DESCRIPTION
Parts of the [builds API](https://buildkite.com/docs/apis/rest-api/builds) supports multiple branches being specified. This adds that support, much in the same way that the `state` parameter is implemented.