### PR TITLE
feat: add support for multiple commits in builds API calls

### DIFF
--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import List
+from typing import List, Optional, Union
 
 from pybuildkite.client import Client
 from pybuildkite.exceptions import (
@@ -107,9 +107,9 @@ class Builds(Client):
             "created_from": self.__api_date_format(created_from),
             "created_to": self.__api_date_format(created_to),
             "finished_from": self.__api_date_format(finished_from),
-            "state": self.__get_build_states_query_param(states),
-            "branch": self.__get_branches_query_param(branch),
-            "commit": commit,
+            "state": self.__get_query_param("state", [s.value for s in states]),
+            "branch": self.__get_query_param("branch", branch),
+            "commit": self.__get_query_param("commit", commit),
             "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
         }
@@ -162,9 +162,9 @@ class Builds(Client):
             "created_from": self.__api_date_format(created_from),
             "created_to": self.__api_date_format(created_to),
             "finished_from": self.__api_date_format(finished_from),
-            "state": self.__get_build_states_query_param(states),
-            "branch": self.__get_branches_query_param(branch),
-            "commit": commit,
+            "state": self.__get_query_param("state", [s.value for s in states]),
+            "branch": self.__get_query_param("branch", branch),
+            "commit": self.__get_query_param("commit", commit),
             "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
         }
@@ -221,9 +221,9 @@ class Builds(Client):
             "created_from": self.__api_date_format(created_from),
             "created_to": self.__api_date_format(created_to),
             "finished_from": self.__api_date_format(finished_from),
-            "state": self.__get_build_states_query_param(states),
-            "branch": self.__get_branches_query_param(branch),
-            "commit": commit,
+            "state": self.__get_query_param("state", [s.value for s in states]),
+            "branch": self.__get_query_param("branch", branch),
+            "commit": self.__get_query_param("commit", commit),
             "include_retried_jobs": True if include_retried_jobs is True else None,
             "page": page,
         }
@@ -354,26 +354,14 @@ class Builds(Client):
                 raise NotValidBuildState
 
     @staticmethod
-    def __get_build_states_query_param(states):
-        if not states:
-            return None
-        if len(states) == 1:
-            return "state=" + states[0].value
-        else:
-            param_string = ""
-            for state in states:
-                param_string += "state[]={}&".format(state.value)
-            return param_string[:-1]
-
-    @staticmethod
-    def __get_branches_query_param(branches):
-        if not branches:
+    def __get_query_param(param_name: str, items: Union[str, list[str]]) -> Optional[str]:
+        if not items:
             return None
 
-        if isinstance(branches, List):
-            param_string = ""
-            for branch in branches:
-                param_string += "branch[]={}&".format(branch)
-            return param_string[:-1]
-        else:
-            return "branch=" + branches
+        if not isinstance(items, List):
+            return f"{param_name}={items}"
+
+        if len(items) == 1:
+            return f"{param_name}={items[0]}"
+
+        return "&".join(f"{param_name}[]={item}" for item in items)

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -219,12 +219,10 @@ class Client(object):
         for key, value in query_params.items():
             if query_string != "":
                 query_string += "&"
-            if key == "state":
-                query_string += value
-            elif key == "branch":
+            if key in ["state", "branch", "commit"]:
                 query_string += value
             else:
-                query_string += key + "=" + str(value)
+                query_string += f"{key}={str(value)}"
         return query_string
 
 

--- a/tests/test_builds.py
+++ b/tests/test_builds.py
@@ -229,6 +229,25 @@ def test_multi_branch(fake_client):
     args = fake_client.get.call_args[0][1]
     assert args["branch"] == "branch[]=main&branch[]=master"
 
+@pytest.mark.parametrize(
+    "commit, result",
+    [
+        ("012abcdef", "commit=012abcdef"), # single item
+        (["012abcdef"], "commit=012abcdef"), # single item in an array
+        (["012abcdef", "013abcdef"], "commit[]=012abcdef&commit[]=013abcdef"), # multiple items
+    ]
+)
+def test_commit_query_param(fake_client, commit, result):
+    builds = Builds(fake_client, "https://api.buildkite.com/v2/")
+    builds.rebuild_build("org_slug", "pipeline_id", "build_number")
+
+    builds.list_all_for_pipeline(
+        organization="org", pipeline="pipe", commit=commit
+    )
+
+    args = fake_client.get.call_args[0][1]
+    assert args["commit"] == result
+
 
 def test_single_branch(fake_client):
     builds = Builds(fake_client, "https://api.buildkite.com/v2/")


### PR DESCRIPTION
This PR adds support for multiple commit query capability to the build API calls. It unifies the query parameter building logic into one for states, branches and commits.

Reference: https://buildkite.com/docs/apis/rest-api/builds#list-all-builds