### PR TITLE
Add per_page parameter to control API response size

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,31 @@ builds = buildkite.builds().list_all_for_pipeline('my-org', 'my-pipeline', state
 # Create a build
 buildkite.builds().create_build('my-org', 'my-pipeline', 'COMMITSHA', 'master', 
 clean_checkout=True, message="My First Build!")
+
+# For organizations with large datasets that experience timeouts, reduce the per_page parameter
+buildkite_small = Buildkite(per_page=25)  # Default is 100
+buildkite_small.set_access_token('YOUR_API_ACCESS_TOKEN_HERE')
+builds = buildkite_small.builds().list_all_for_org('my-org')
+```
+
+## Per-Page Configuration
+
+The `per_page` parameter controls the number of items returned per API request. This can be useful for organizations with large datasets that experience timeouts.
+
+```python
+# Default behavior (100 items per page)
+buildkite = Buildkite()
+
+# Custom per_page for smaller responses (useful for large organizations)
+buildkite = Buildkite(per_page=25)
+
+# Very small per_page for testing or very large datasets
+buildkite = Buildkite(per_page=10)
 ```
 
 ## Pagination
 
-Buildkite offers pagination for endpoints that return a lot of data. By default this wrapper return `100` objects. However, any request that may contain more than that offers a pagination option.
+Buildkite offers pagination for endpoints that return a lot of data. By default this wrapper returns `100` objects per page. However, any request that may contain more than that offers a pagination option.
 
 When `with_pagination=True`, we return a response object with properties that may have `next_page`, `last_page`, `previous_page`, or `first_page` depending on what page you're on.
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,6 @@ builds = buildkite.builds().list_all_for_pipeline('my-org', 'my-pipeline', state
 # Create a build
 buildkite.builds().create_build('my-org', 'my-pipeline', 'COMMITSHA', 'master', 
 clean_checkout=True, message="My First Build!")
-
-# For organizations with large datasets that experience timeouts, reduce the per_page parameter
-buildkite_small = Buildkite(per_page=25)  # Default is 100
-buildkite_small.set_access_token('YOUR_API_ACCESS_TOKEN_HERE')
-builds = buildkite_small.builds().list_all_for_org('my-org')
 ```
 
 ## Per-Page Configuration
@@ -49,9 +44,6 @@ buildkite = Buildkite()
 
 # Custom per_page for smaller responses (useful for large organizations)
 buildkite = Buildkite(per_page=25)
-
-# Very small per_page for testing or very large datasets
-buildkite = Buildkite(per_page=10)
 ```
 
 ## Pagination

--- a/pybuildkite/buildkite.py
+++ b/pybuildkite/buildkite.py
@@ -19,11 +19,13 @@ class Buildkite(object):
     Public API for Buildkite
     """
 
-    def __init__(self):
+    def __init__(self, per_page=100):
         """
         Create a new client
+        
+        :param per_page: Number of items per page for API requests (default: 100)
         """
-        self.client = Client()
+        self.client = Client(per_page)
         self.base_url = "https://api.buildkite.com/v2/"
 
     def set_access_token(self, access_token):

--- a/pybuildkite/client.py
+++ b/pybuildkite/client.py
@@ -7,11 +7,14 @@ class Client(object):
     Internal API Client
     """
 
-    def __init__(self):
+    def __init__(self, per_page=100):
         """
         Create class
+        
+        :param per_page: Number of items per page for API requests (default: 100)
         """
         self.access_token = ""
+        self.per_page = per_page
 
     def is_access_token_set(self):
         """
@@ -67,7 +70,7 @@ class Client(object):
             body = self._clean_query_params(body)
 
         query_params = self._clean_query_params(query_params or {})
-        query_params["per_page"] = "100"
+        query_params["per_page"] = str(self.per_page)
 
         query_params = self._convert_query_params_to_string_for_bytes(query_params)
         response = requests.request(

--- a/tests/test_buildkite.py
+++ b/tests/test_buildkite.py
@@ -34,6 +34,24 @@ def test_access_token_set():
     assert buildkite.agents()
 
 
+def test_buildkite_with_custom_per_page():
+    """
+    Test that Buildkite class accepts and uses custom per_page parameter
+    """
+    buildkite = Buildkite(per_page=50)
+    buildkite.set_access_token("FAKE-ACCESS-TOKEN")
+    assert buildkite.client.per_page == 50
+    assert buildkite.agents()
+
+
+def test_buildkite_default_per_page():
+    """
+    Test that Buildkite class uses default per_page value
+    """
+    buildkite = Buildkite()
+    assert buildkite.client.per_page == 100
+
+
 @pytest.mark.parametrize(
     "function, expected_type",
     [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,6 +19,37 @@ class TestClient:
         client.set_client_access_token("FAKE-TOKEN")
         assert client.is_access_token_set()
 
+    def test_per_page_parameter(self):
+        """
+        Test that per_page parameter is properly set and used
+        """
+        client = Client(per_page=50)
+        assert client.per_page == 50
+        
+        # Test default value
+        client_default = Client()
+        assert client_default.per_page == 100
+
+    def test_request_with_custom_per_page(self):
+        """
+        Test that custom per_page value is used in requests
+        """
+        fake_client = Client(per_page=25)
+
+        with patch("requests.request") as request:
+            request.return_value.json.return_value = {}
+
+            fake_client.request("GET", "http://www.google.com/")
+
+        request.assert_called_once_with(
+            "GET",
+            "http://www.google.com/",
+            headers={},
+            json=None,
+            params=b"per_page=25",
+            stream=False,
+        )
+
     def test_clean_query_params(self):
         """
         Test that params with None are cleaned


### PR DESCRIPTION
This PR adds a per_page parameter to the Buildkite class constructor to allow users to control the number of items returned per API request.