### PR TITLE
Change API date format to UTC string

### DIFF
--- a/pybuildkite/builds.py
+++ b/pybuildkite/builds.py
@@ -345,7 +345,7 @@ class Builds(Client):
     def __api_date_format(datetime):
         if datetime is None:
             return None
-        return datetime.isoformat()
+        return datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     @staticmethod
     def __are_valid_states(states):


### PR DESCRIPTION
Buildkite takes a datetime formatted like `2025-09-14T21:39:53Z` per https://buildkite.com/docs/apis/rest-api/builds.

Raw isoformat looks like `2025-09-17T00:00:00+00:00` which causes buildkite to return an error like
```
Failed to execute: 422 Client Error: Unprocessable Content for url: https://api.buildkite.com/v2/organizations/snowci/pipelines/pull-request-basic/builds?finished_from=2025-09-17T00:00:00.950000+00:00&state[]=passed&state[]=failed&state[]=skipped&state[]=canceled&state[]=not_run&page=0&per_page=100","success":false
```